### PR TITLE
added batchsize for embedding density

### DIFF
--- a/docs/release-notes/0.9.1.md
+++ b/docs/release-notes/0.9.1.md
@@ -1,0 +1,5 @@
+### 0.9.0 {small}`the future`
+
+```{rubric} Features
+```
+* added batchsize for {func}`~rapids_singlecell.tl.embedding_density` {pr}`67` {smaller}`S Dicks`

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -3,6 +3,8 @@
 # Release notes
 
 ## Version 0.9.0
+```{include} /release-notes/0.9.1.md
+``````
 
 ```{include} /release-notes/0.9.0.md
 ```


### PR DESCRIPTION
This adds a `batchsize` argument for embedding density. This can prevent memory errors for larger datasets