### PR TITLE
Remove unsupported param from .cirun.yml

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -5,6 +5,5 @@ runners:
     machine_image: ami-067a4ba2816407ee9
     region: eu-north-1
     preemptible: false
-    workflow: .github/workflows/test-gpu.yml
     labels:
       - cirun-aws-gpu


### PR DESCRIPTION
`workflow` param is not supported and it's misleading. Runner matching is done only via labels.
See: https://docs.cirun.io/