### PR TITLE
Use preemptible images for ci

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -4,6 +4,8 @@ runners:
     instance_type: g4dn.xlarge
     machine_image: ami-067a4ba2816407ee9
     region: eu-north-1
-    preemptible: false
+    preemptible:
+      - true
+      - false
     labels:
       - cirun-aws-gpu


### PR DESCRIPTION
We switched anndata over to pre-emptable images a while ago, and it's way cheaper with no issues caused. I'd suggest we do that here too.

It looks like a job here takes ~3 times as long, but costs ~20x more.