### PR TITLE
Canconial matrix update

### DIFF
--- a/docs/release-notes/0.10.1.md
+++ b/docs/release-notes/0.10.1.md
@@ -5,6 +5,7 @@
 
 ```{rubric} Bug fixes
 ```
+* updates the behavior of `_check_gpu_X` for `require_cf`. It now only works for `pearson_residuals` calcs and corrects instead of throwing an error {pr}`154` {smaller}`S Dicks`
 
 ```{rubric} Misc
 ```

--- a/src/rapids_singlecell/preprocessing/_hvg.py
+++ b/src/rapids_singlecell/preprocessing/_hvg.py
@@ -156,7 +156,7 @@ def highly_variable_genes(
     else:
         if batch_key is None:
             X = _get_obs_rep(adata, layer=layer)
-            _check_gpu_X(X, require_cf=True)
+            _check_gpu_X(X)
             df = _highly_variable_genes_single_batch(
                 X.copy(),
                 min_disp=min_disp,
@@ -173,7 +173,7 @@ def highly_variable_genes(
             df = []
             genes = adata.var.index.to_numpy()
             X = adata.layers[layer] if layer is not None else adata.X
-            _check_gpu_X(X, require_cf=True)
+            _check_gpu_X(X)
             for batch in batches:
                 if not isinstance(X, cp.ndarray):
                     X_batch = X[adata.obs[batch_key] == batch,].tocsc()
@@ -419,7 +419,7 @@ def _highly_variable_genes_seurat_v3(
 
     df = pd.DataFrame(index=adata.var.index)
     X = _get_obs_rep(adata, layer=layer)
-    _check_gpu_X(X, require_cf=True)
+    _check_gpu_X(X)
     if check_values and not _check_nonnegative_integers(X):
         warnings.warn(
             "`flavor='seurat_v3'` expects raw count data, but non-integers were found.",

--- a/src/rapids_singlecell/preprocessing/_scale.py
+++ b/src/rapids_singlecell/preprocessing/_scale.py
@@ -75,7 +75,7 @@ def scale(
         view_to_actual(adata)
 
     X = _get_obs_rep(adata, layer=layer, obsm=obsm)
-    _check_gpu_X(X, require_cf=True)
+    _check_gpu_X(X)
 
     str_mean_std = ("mean", "std")
     if mask_obs is not None:

--- a/src/rapids_singlecell/preprocessing/_utils.py
+++ b/src/rapids_singlecell/preprocessing/_utils.py
@@ -92,12 +92,8 @@ def _check_gpu_X(X, require_cf=False):
         if X.has_canonical_format or not require_cf:
             return True
         else:
-            raise ValueError(
-                "The input sparse matrix is not in canonical format. "
-                "Please convert it to canonical format. "
-                "This can be done with `X.sum_duplicates()` "
-                "and `X.sort_indices()`."
-            )
+            X.sort_indices()
+            X.sum_duplicates()
     else:
         raise TypeError(
             "The input is not a CuPy ndarray or CuPy sparse matrix. "


### PR DESCRIPTION
updates the behavior of `_check_gpu_X` for require_cf. It now only works for `pearson_residuals` calcs and corrects instead of throwing an error