### PR TITLE
switch to reduction kernels for dense mean var

### DIFF
--- a/src/rapids_singlecell/preprocessing/_kernels/_mean_var_kernel.py
+++ b/src/rapids_singlecell/preprocessing/_kernels/_mean_var_kernel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import cupy as cp
 from cuml.common.kernel_utils import cuda_kernel_factory
 
 _get_mean_var_major_kernel = r"""
@@ -56,6 +57,27 @@ _get_mean_var_minor_kernel = r"""
        atomicAdd(&vars[minor_pos], value*value/major);
         }
     """
+
+
+sq_sum = cp.ReductionKernel(
+    "T x",  # input params
+    "float64 y",  # output params
+    "x * x",  # map
+    "a + b",  # reduce
+    "y = a",  # post-reduction map
+    "0",  # identity value
+    "sqsum64",  # kernel name
+)
+
+mean_sum = cp.ReductionKernel(
+    "T x",  # input params
+    "float64 y",  # output params
+    "x",  # map
+    "a + b",  # reduce
+    "y = a",  # post-reduction map
+    "0",  # identity value
+    "sum64",  # kernel name
+)
 
 
 def _get_mean_var_major(dtype):

--- a/src/rapids_singlecell/preprocessing/_utils.py
+++ b/src/rapids_singlecell/preprocessing/_utils.py
@@ -38,6 +38,17 @@ def _mean_var_minor(X, major, minor):
     return mean, var
 
 
+def _mean_var_dense(X, axis):
+    from ._kernels._mean_var_kernel import mean_sum, sq_sum
+
+    var = sq_sum(X, axis=axis)
+    mean = mean_sum(X, axis=axis)
+    mean = mean / X.shape[axis]
+    var = var / X.shape[axis]
+    var -= cp.power(mean, 2)
+    var *= X.shape[axis] / (X.shape[axis] - 1)
+
+
 def _get_mean_var(X, axis=0):
     if issparse(X):
         if axis == 0:
@@ -64,9 +75,7 @@ def _get_mean_var(X, axis=0):
                 minor = X.shape[0]
                 mean, var = _mean_var_minor(X, major, minor)
     else:
-        mean = X.mean(axis=axis)
-        var = X.var(axis=axis)
-        var *= X.shape[axis] / (X.shape[axis] - 1)
+        mean, var = _mean_var_dense(X, axis)
     return mean, var
 
 


### PR DESCRIPTION
This moves from cupy ufuncs to reduction kernels for dense mean var. This allows for 64bit computation