### PR TITLE
(fix): use `to_delayed` and `from_delayed` to submit gram matrix jobs 

### DIFF
--- a/src/rapids_singlecell/preprocessing/_pca.py
+++ b/src/rapids_singlecell/preprocessing/_pca.py
@@ -92,7 +92,7 @@ def pca(
             Required if `chunked=True` was passed.
 
         client
-            Dask client to use for computation. If `None`, the default client is used. Only used if `X` is a Dask array.
+            Dask client to use for computation. If `None`, the default client is used. Only used if `X` is a dense Dask array.
 
     Returns
     -------

--- a/src/rapids_singlecell/preprocessing/_pca.py
+++ b/src/rapids_singlecell/preprocessing/_pca.py
@@ -151,7 +151,7 @@ def pca(
         elif isinstance(X._meta, csr_matrix):
             from ._sparse_pca._dask_sparse_pca import PCA_sparse_dask
 
-            pca_func = PCA_sparse_dask(n_components=n_comps, client=client)
+            pca_func = PCA_sparse_dask(n_components=n_comps)
             pca_func = pca_func.fit(X)
             X_pca = pca_func.transform(X)
 

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -4,7 +4,6 @@ import math
 
 import cupy as cp
 import dask
-from cuml.dask.common.part_utils import _extract_partitions
 from cuml.internals.memory_utils import with_cupy_rmm
 
 from rapids_singlecell._compat import (
@@ -174,8 +173,15 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         return gram_matrix
 
     blocks = x.to_delayed().ravel()
-    gram_chunk_matrices = dask.array.map_blocks(__gram_block, meta=cp.array((1.,), dtype=x.dtype), dtype=x.dtype, chunks=((x.shape[0],) * len(blocks), (x.shape[1],)))
-    gram_chunk_matrices = gram_chunk_matrices.reshape(len(blocks), x.shape[0], x.shape[1])
+    gram_chunk_matrices = dask.array.map_blocks(
+        __gram_block,
+        meta=cp.array((1.0,), dtype=x.dtype),
+        dtype=x.dtype,
+        chunks=((x.shape[0],) * len(blocks), (x.shape[1],)),
+    )
+    gram_chunk_matrices = gram_chunk_matrices.reshape(
+        len(blocks), x.shape[0], x.shape[1]
+    )
     gram_matrix = gram_chunk_matrices.sum(axis=0).compute()
     mean_x, _ = _get_mean_var(x, client=client)
     mean_x = mean_x.astype(x.dtype)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -174,9 +174,8 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         return gram_matrix
 
     blocks = x.to_delayed().ravel()
-    gram_chunk_matrices = dask.array.map_blocks(
+    gram_chunk_matrices = x.map_blocks(
         __gram_block,
-        x,
         meta=cp.array((1.0,), dtype=x.dtype),
         dtype=x.dtype,
         chunks=((x.shape[1],) * len(blocks), (x.shape[1],)),

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -173,12 +173,12 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         )
         return gram_matrix
 
-    blocks = x.to_delayed().ravel()
+    num_blocks = len(x.to_delayed().ravel())
     gram_chunk_matrices = x.map_blocks(
         __gram_block,
         meta=cp.array((1.0,), dtype=x.dtype),
         dtype=x.dtype,
-        chunks=((1,) * len(blocks), (x.shape[1],), (x.shape[1],)),
+        chunks=((1,) * num_blocks, (x.shape[1],), (x.shape[1],)),
         new_axis=1,
     )
     gram_matrix = gram_chunk_matrices.sum(axis=0).compute()

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -177,10 +177,10 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         __gram_block,
         meta=cp.array((1.0,), dtype=x.dtype),
         dtype=x.dtype,
-        chunks=((x.shape[0],) * len(blocks), (x.shape[1],)),
+        chunks=((x.shape[1],) * len(blocks), (x.shape[1],)),
     )
     gram_chunk_matrices = gram_chunk_matrices.reshape(
-        len(blocks), x.shape[0], x.shape[1]
+        len(blocks), x.shape[1], x.shape[1]
     )
     gram_matrix = gram_chunk_matrices.sum(axis=0).compute()
     mean_x, _ = _get_mean_var(x, client=client)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 
 import cupy as cp
-import dask
 from cuml.internals.memory_utils import with_cupy_rmm
 
 from rapids_singlecell._compat import (
@@ -152,10 +151,9 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
     compute_mean_cov = _gramm_kernel_csr(x.dtype)
     compute_mean_cov.compile()
 
-    @dask.delayed
     def __gram_block(x_part):
         n_cols = x_part.shape[1]
-        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x.dtype)
+        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x_part.dtype)
 
         block = (128,)
         grid = (x_part.shape[0],)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -153,8 +153,9 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
     compute_mean_cov.compile()
 
     @dask.delayed
-    def __gram_block(x_part, n_cols):
-        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x.dtype)
+    def __gram_block(x_part):
+        n_cols = x_part.shape[1]
+        gram_matrix = cp.zeros(n_cols, dtype=x.dtype)
 
         block = (128,)
         grid = (x_part.shape[0],)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -179,8 +179,8 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         chunks=((1,) * num_blocks, (x.shape[1],), (x.shape[1],)),
         new_axis=1,
     )
-    gram_matrix = gram_chunk_matrices.sum(axis=0).compute()
-    print(gram_matrix)
+    # TODO: calling .sum(axis=0) for some reason returns a `numpy` array immediately?
+    gram_matrix = cp.sum(gram_chunk_matrices, axis=0).compute()
     mean_x, _ = _get_mean_var(x, client=client)
     mean_x = mean_x.astype(x.dtype)
     copy_gram = _copy_kernel(x.dtype)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -153,7 +153,7 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
 
     def __gram_block(x_part):
         n_cols = x_part.shape[1]
-        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x_part.dtype)
+        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x.dtype)
 
         block = (128,)
         grid = (x_part.shape[0],)
@@ -180,6 +180,7 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         new_axis=1,
     )
     gram_matrix = gram_chunk_matrices.sum(axis=0).compute()
+    print(gram_matrix)
     mean_x, _ = _get_mean_var(x, client=client)
     mean_x = mean_x.astype(x.dtype)
     copy_gram = _copy_kernel(x.dtype)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -155,7 +155,7 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
     @dask.delayed
     def __gram_block(x_part):
         n_cols = x_part.shape[1]
-        gram_matrix = cp.zeros(n_cols, dtype=x.dtype)
+        gram_matrix = cp.zeros((n_cols, n_cols), dtype=x.dtype)
 
         block = (128,)
         grid = (x_part.shape[0],)
@@ -178,10 +178,8 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
         __gram_block,
         meta=cp.array((1.0,), dtype=x.dtype),
         dtype=x.dtype,
-        chunks=((x.shape[1],) * len(blocks), (x.shape[1],)),
-    )
-    gram_chunk_matrices = gram_chunk_matrices.reshape(
-        len(blocks), x.shape[1], x.shape[1]
+        chunks=((1,) * len(blocks), (x.shape[1],), (x.shape[1],)),
+        new_axis=1,
     )
     gram_matrix = gram_chunk_matrices.sum(axis=0).compute()
     mean_x, _ = _get_mean_var(x, client=client)

--- a/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
+++ b/src/rapids_singlecell/preprocessing/_sparse_pca/_dask_sparse_pca.py
@@ -175,6 +175,7 @@ def _cov_sparse_dask(client, x, return_gram=False, return_mean=False):
     blocks = x.to_delayed().ravel()
     gram_chunk_matrices = dask.array.map_blocks(
         __gram_block,
+        x,
         meta=cp.array((1.0,), dtype=x.dtype),
         dtype=x.dtype,
         chunks=((x.shape[1],) * len(blocks), (x.shape[1],)),


### PR DESCRIPTION
This refactors so that there is no need to `_extract_partitions` and use `client.submit` which seems to really help with task graph craziness and also doesn't require persisting.