### PR TITLE
remove older rapids check

### DIFF
--- a/docs/release-notes/0.10.7.md
+++ b/docs/release-notes/0.10.7.md
@@ -11,6 +11,7 @@
 
 ```{rubric} Bug fixes
 ```
+* Removes support for older rapids with `tl.louvain` that cause issues {pr}`226` {smaller}`S Dicks`
 
 ```{rubric} Misc
 ```

--- a/src/rapids_singlecell/tools/_clustering.py
+++ b/src/rapids_singlecell/tools/_clustering.py
@@ -7,7 +7,6 @@ import cudf
 import numpy as np
 import pandas as pd
 from natsort import natsorted
-from packaging import version
 from scanpy.tools._utils import _choose_graph
 from scanpy.tools._utils_clustering import rename_groups, restrict_adjacency
 
@@ -236,7 +235,6 @@ def louvain(
 
     """
     # Adjacency graph
-    from cugraph import __version__ as cuv
     from cugraph import louvain as culouvain
 
     adata = adata.copy() if copy else adata
@@ -253,20 +251,11 @@ def louvain(
 
     g = _create_graph(adjacency, use_weights)
 
-    # Cluster
-    if version.parse(cuv) >= version.parse("23.08.00"):
-        louvain_parts, _ = culouvain(
-            g,
-            resolution=resolution,
-            max_level=n_iterations,
-            threshold=threshold,
-        )
-    else:
-        louvain_parts, _ = culouvain(
-            g,
-            resolution=resolution,
-            max_iter=n_iterations,
-        )
+    louvain_parts, _ = culouvain(
+        g,
+        resolution=resolution,
+        max_iter=n_iterations,
+    )
 
     # Format output
     groups = (

--- a/src/rapids_singlecell/tools/_clustering.py
+++ b/src/rapids_singlecell/tools/_clustering.py
@@ -251,10 +251,12 @@ def louvain(
 
     g = _create_graph(adjacency, use_weights)
 
+    # Cluster
     louvain_parts, _ = culouvain(
         g,
         resolution=resolution,
-        max_iter=n_iterations,
+        max_level=n_iterations,
+        threshold=threshold,
     )
 
     # Format output


### PR DESCRIPTION
This removes support for older rapids versions for louvain clustering