### PR TITLE
Fix small error introduced by PR #264

### DIFF
--- a/src/rapids_singlecell/preprocessing/_neighbors.py
+++ b/src/rapids_singlecell/preprocessing/_neighbors.py
@@ -386,7 +386,7 @@ def neighbors(
         metric=metric,
         **({"metric_kwds": metric_kwds} if metric_kwds else {}),
         **({"use_rep": use_rep} if use_rep is not None else {}),
-        **({"use_rep": n_pcs} if n_pcs is not None else {}),
+        **({"n_pcs": n_pcs} if n_pcs is not None else {}),
     )
     neighbors_dict = {
         "connectivities_key": conns_key,


### PR DESCRIPTION
In #264 's changes to `_neighbors`, while building a params dict, I think some code inadvertently got copy-pasted incorrectly [here](https://github.com/scverse/rapids_singlecell/blame/2e2d54ff01d51a72b0965ec9c0a483d0ea880ba3/src/rapids_singlecell/preprocessing/_neighbors.py#L389). This PR fixes that error.