### PR TITLE
Expand H1 and H2 headers in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,7 @@ html_theme_options = {
     "repository_branch": os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main"),
     "use_repository_button": True,
     "navigation_with_keys": False,
+    "show_toc_level": 2,
 }
 html_show_sphinx = False
 html_logo = "_static/logo_RTD.svg"


### PR DESCRIPTION
We are now also expanding H1 and H2 headers in the documentation.

Before:

<img width="282" height="200" alt="image" src="https://github.com/user-attachments/assets/6c40f521-3a4a-4bfa-a896-f44e8b6529a3" />

After:

<img width="234" height="594" alt="image" src="https://github.com/user-attachments/assets/f6f3cf26-b950-4c9e-af3a-918b6a1fba8f" />
