### PR TITLE
Drop cuml.thirdparty_adapters.check_array dependency

### DIFF
--- a/docs/release-notes/0.15.1.md
+++ b/docs/release-notes/0.15.1.md
@@ -16,3 +16,4 @@
 * ``adata.uns[key_added]["params"]["resolution"]`` is now stored as a scalar ``float`` when a single resolution
 is passed to ``tl.leiden`` and ``tl.louvain`` to match behaviour in Scanpy, and as a ``list`` when multiple
 resolutions are passed. Previously it was always stored as a list. {pr}`648`. {smaller}`J Pintar`
+* Drop dependency on ``cuml.thirdparty_adapters.check_array`` (removed in cuml 26.06); ``init_pos`` validation in ``tl.umap`` and ``tl.draw_graph`` is now handled locally {pr}`660` {smaller}`S Dicks`

--- a/src/rapids_singlecell/tools/_draw_graph.py
+++ b/src/rapids_singlecell/tools/_draw_graph.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING
 import cudf
 import cupy as cp
 import numpy as np
-from cuml.thirdparty_adapters import check_array as check_array_cuml
 from scanpy.tools._utils import get_init_pos_from_paga
 
 from rapids_singlecell._compat import _random_state_kwargs
 
 from ._clustering import _create_graph
+from ._utils import _validate_init_pos
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -67,9 +67,7 @@ def draw_graph(
         case _:
             init_coords = init_pos
     if hasattr(init_coords, "dtype"):
-        init_coords = check_array_cuml(
-            init_coords, dtype=np.float32, accept_sparse=False
-        )
+        init_coords = _validate_init_pos(init_coords)
         if init_coords.shape[1] != 2:
             raise ValueError(
                 f"Expected 2 columns but got {init_coords.shape[1]} columns."

--- a/src/rapids_singlecell/tools/_umap.py
+++ b/src/rapids_singlecell/tools/_umap.py
@@ -7,7 +7,6 @@ import cuml.internals.logger as logger
 import cupy as cp
 import numpy as np
 from cuml.manifold.umap import UMAP, find_ab_params, simplicial_set_embedding
-from cuml.thirdparty_adapters import check_array as check_array_cuml
 from cupyx.scipy import sparse
 from packaging.version import parse as parse_version
 from scanpy._utils import NeighborsView
@@ -17,7 +16,7 @@ from sklearn.utils import check_random_state
 from rapids_singlecell._compat import _random_state_kwargs
 from rapids_singlecell._utils import _get_logger_level
 
-from ._utils import _choose_representation
+from ._utils import _choose_representation, _validate_init_pos
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -216,9 +215,7 @@ def umap(
                 init_coords = init_pos
 
         if hasattr(init_coords, "dtype"):
-            init_coords = check_array_cuml(
-                init_coords, dtype=np.float32, accept_sparse=False
-            )
+            init_coords = _validate_init_pos(init_coords)
 
         random_state = check_random_state(random_state)
 

--- a/src/rapids_singlecell/tools/_utils.py
+++ b/src/rapids_singlecell/tools/_utils.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 import cupy as cp
+import scipy.sparse as cpu_sparse
 from cupyx.scipy.sparse import issparse, isspmatrix_csc, isspmatrix_csr
 
 from rapids_singlecell._compat import DaskArray
 
 from . import pca
+
+
+def _validate_init_pos(init_coords):
+    """Coerce a user-supplied `init_pos` array to a 2D cupy float32 array.
+
+    Replaces the previous use of ``cuml.thirdparty_adapters.check_array``, which was
+    removed in cuml 26.06.
+    """
+    if cpu_sparse.issparse(init_coords) or issparse(init_coords):
+        raise ValueError("Sparse `init_pos` is not supported.")
+    arr = cp.asarray(init_coords, dtype=cp.float32)
+    if arr.ndim != 2:
+        raise ValueError(f"Expected 2D `init_pos`, got {arr.ndim}D array.")
+    return arr
 
 
 def _choose_representation(adata, use_rep=None, n_pcs=None):


### PR DESCRIPTION
 cuml 26.06 removed check_array from cuml.thirdparty_adapters (rapidsai/cuml#8052), breaking the rapids-prerelease CI matrix. Replaces the two check_array_cuml(init_coords, dtype=np.float32, accept_sparse=False) call sites in _draw_graph.py and _umap.py with a small local _validate_init_pos helper in tools/_utils.py — same behavior (reject sparse, coerce to cupy float32, ensure 2D), no cuml-internal dependency.