### PR TITLE
Fix/no mutate input pearson residuals

### DIFF
--- a/docs/release-notes/0.15.1.md
+++ b/docs/release-notes/0.15.1.md
@@ -10,6 +10,7 @@
 * Fixes `tl.rank_genes_groups` returning NaN/zero `logfoldchanges`/`pvals` with `groups=[subset]` and `reference='rest'` {pr}`651` {smaller}`S Dicks`
 * Fixes `pp.bbknn` connectivities diverging from upstream `bbknn`: per-batch neighbours are now sorted by distance before `fuzzy_simplicial_set` (so weights no longer collapse near 1.0), and the default `trim` matches upstream (`10 * neighbors_within_batch * n_batches`). Trimming kernel no longer crashes for large `trim`, and a new block-cooperative sort kernel is auto-dispatched for large `trim` for substantial speedups {pr}`659` {smaller}`S Dicks`
 * Fixes float64 precision loss in `pp.normalize_pearson_residuals` on CSR/CSC input {pr}`658` {smaller}`A Mikaeili & S Dicks`
+* `pp.normalize_pearson_residuals` and `pp.highly_variable_genes` with `flavor='pearson_residuals'` no longer mutate the input matrix: a non-canonical sparse `adata.X` was previously sorted and de-duplicated in place by `_check_gpu_X`; canonicalization now happens on a copy {pr}`xxx` {smaller}`A Mikaeili`
 
 ```{rubric} Misc
 ```

--- a/src/rapids_singlecell/preprocessing/_hvg/_pearson_residuals.py
+++ b/src/rapids_singlecell/preprocessing/_hvg/_pearson_residuals.py
@@ -13,6 +13,7 @@ from rapids_singlecell._cuda import _pr_cuda
 from rapids_singlecell.preprocessing._utils import (
     _check_gpu_X,
     _check_nonnegative_integers,
+    _ensure_canonical_format,
     _get_mean_var,
 )
 
@@ -39,7 +40,8 @@ def _highly_variable_pearson_residuals(
     Expects raw count input.
     """
     X = _get_obs_rep(adata, layer=layer)
-    _check_gpu_X(X, require_cf=True)
+    _check_gpu_X(X)
+    X = _ensure_canonical_format(X)
     if check_values and not _check_nonnegative_integers(X):
         warnings.warn(
             "`flavor='pearson_residuals'` expects raw count data, but non-integers were found.",

--- a/src/rapids_singlecell/preprocessing/_normalize.py
+++ b/src/rapids_singlecell/preprocessing/_normalize.py
@@ -16,7 +16,11 @@ from rapids_singlecell._compat import (
     _meta_sparse,
 )
 
-from ._utils import _check_gpu_X, _check_nonnegative_integers
+from ._utils import (
+    _check_gpu_X,
+    _check_nonnegative_integers,
+    _ensure_canonical_format,
+)
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -457,7 +461,8 @@ def normalize_pearson_residuals(
     """
     X = _get_obs_rep(adata, layer=layer)
 
-    _check_gpu_X(X, require_cf=True)
+    _check_gpu_X(X)
+    X = _ensure_canonical_format(X)
 
     if check_values and not _check_nonnegative_integers(X):
         warnings.warn(

--- a/src/rapids_singlecell/preprocessing/_utils.py
+++ b/src/rapids_singlecell/preprocessing/_utils.py
@@ -283,7 +283,13 @@ def _check_nonnegative_integers(X):
         return True
 
 
-def _check_gpu_X(X, *, require_cf=False, allow_dask=False, allow_csc=True):
+def _check_gpu_X(X, *, allow_dask=False, allow_csc=True):
+    """Validate that ``X`` is a GPU matrix supported by this function.
+
+    This is a pure validator: it raises :class:`TypeError` on unsupported
+    input and returns ``True`` otherwise. It never modifies ``X``. When a
+    kernel requires canonical sparse format, use :func:`_ensure_canonical_format`.
+    """
     if isinstance(X, DaskArray):
         if allow_dask:
             return _check_gpu_X(X._meta, allow_csc=False)
@@ -301,13 +307,7 @@ def _check_gpu_X(X, *, require_cf=False, allow_dask=False, allow_csc=True):
                 "When using Dask, only CuPy ndarrays and CSR matrices are supported as "
                 "meta arrays. Please convert your data to CSR format if it is in CSC."
             )
-        elif not require_cf:
-            return True
-        elif X.has_canonical_format:
-            return True
-        else:
-            X.sort_indices()
-            X.sum_duplicates()
+        return True
     else:
         raise TypeError(
             "The input is not a CuPy ndarray or CuPy sparse matrix. "
@@ -316,6 +316,22 @@ def _check_gpu_X(X, *, require_cf=False, allow_dask=False, allow_csc=True):
             "Please checkout `rapids_singlecell.get.anndata_to_GPU` to convert your data to GPU. "
             "If you're working with CPU-based matrices, please consider using Scanpy instead."
         )
+
+
+def _ensure_canonical_format(X):
+    """Return ``X`` in canonical sparse format without mutating the input.
+
+    Some GPU kernels (e.g. the Pearson-residual kernels) co-iterate the
+    sparse structure and require sorted indices with no duplicate entries.
+    If ``X`` is a sparse matrix that is not already in canonical format, a
+    canonicalized **copy** is returned and the caller's matrix is left
+    untouched. Dense and already-canonical inputs are returned unchanged.
+    """
+    if issparse(X) and not X.has_canonical_format:
+        X = X.copy()
+        X.sort_indices()
+        X.sum_duplicates()
+    return X
 
 
 def _check_use_raw(adata: AnnData, layer: str | None, *, use_raw: None | bool) -> bool:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -130,6 +130,38 @@ def test_normalize_pearson_residuals_float64_precision(sparsity_func, theta):
     cp.testing.assert_allclose(output, reference, rtol=1e-9, atol=1e-9)
 
 
+def test_normalize_pearson_residuals_preserves_input_matrix():
+    """Regression test: `normalize_pearson_residuals` must not mutate `adata.X`.
+
+    `_check_gpu_X(..., require_cf=True)` previously canonicalized a
+    non-canonical sparse input *in place* -- it called ``sort_indices()`` and
+    ``sum_duplicates()`` on ``adata.X`` itself. Canonicalization now happens
+    on a copy (``_ensure_canonical_format``), so the caller's matrix is left
+    untouched. With ``inplace=False`` the function does not write ``adata.X``,
+    so the input matrix must come out byte-identical to how it went in.
+    """
+    # non-canonical CSR: unsorted column indices + a duplicate (row, col) entry
+    indptr = cp.array([0, 3, 4, 6], dtype=cp.int32)
+    indices = cp.array([2, 0, 2, 1, 2, 1], dtype=cp.int32)
+    data = cp.array([5.0, 1.0, 3.0, 7.0, 4.0, 2.0], dtype=cp.float64)
+    cudata = AnnData(X=csr_matrix((data, indices, indptr), shape=(3, 3)))
+
+    X = cudata.X
+    assert not X.has_canonical_format, "test premise: input must be non-canonical"
+    indices_before = cp.asnumpy(X.indices).copy()
+    data_before = cp.asnumpy(X.data).copy()
+    nnz_before = X.nnz
+
+    rsc.pp.normalize_pearson_residuals(cudata, inplace=False)
+
+    # the function must not have mutated the input matrix
+    X_after = cudata.X
+    assert X_after.nnz == nnz_before
+    np.testing.assert_array_equal(cp.asnumpy(X_after.indices), indices_before)
+    np.testing.assert_array_equal(cp.asnumpy(X_after.data), data_before)
+    assert not X_after.has_canonical_format
+
+
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("sparse", [True, False])
 @pytest.mark.parametrize("base", [None, 2, 10])


### PR DESCRIPTION
## Summary

`_check_gpu_X` in `src/rapids_singlecell/preprocessing/_utils.py` is named and used as a validator, but when called with `require_cf=True` on a sparse matrix that was not in canonical format it had two defects:

1. **It silently mutated the caller's matrix in place.** It called `X.sort_indices()` and `X.sum_duplicates()` on the object returned by `_get_obs_rep` _ i.e. on `adata.X` itself. The operation is value-preserving, but it reorders the indices, merges duplicate entries and changes `nnz`, so any code holding a reference to the matrix, hashing its buffers, or round-tripping it to disk sees it change underneath them.

2. **It returned inconsistently.** That branch fell through with no `return`, so `_check_gpu_X(..., require_cf=True)` returned `None` for a non-canonical matrix and `True` for an already-canonical one _ different return values for identical calls.

Two callers were affected: `pp.normalize_pearson_residuals` and `pp.highly_variable_genes(flavor='pearson_residuals')`.

## Fix

The two concerns are split:

- **`_check_gpu_X`** is now a pure validator. It drops the `require_cf` parameter, never modifies `X`, and returns `True` on every valid path (raising `TypeError` otherwise).
- **`_ensure_canonical_format(X)`** (new) performs the canonicalization. When `X` is sparse and not already canonical it canonicalizes a **copy** and returns it, leaving the caller's matrix untouched. Dense and already-canonical inputs are returned unchanged with no copy.

The two `require_cf=True` call sites now call `_check_gpu_X(X)` followed by `X = _ensure_canonical_format(X)`, so the GPU kernels still receive a canonical matrix while `adata.X` is no longer mutated.

## Verification

Running the real `_check_gpu_X` and `_ensure_canonical_format` on a non-canonical CSR matrix (NVIDIA H100 80GB, CUDA 12.9):

- `_check_gpu_X(X)` _ returns `True`, leaves `X` byte-for-byte unchanged.
- `_ensure_canonical_format(X)` _ returns a canonical **copy** (same dense values); the original `X` keeps its original `indices`, `data`, `nnz` and `has_canonical_format`.
- `_ensure_canonical_format` on an already-canonical matrix returns the same object _ no needless copy.

## Changes

- `preprocessing/_utils.py` _ `_check_gpu_X` becomes a pure validator; new `_ensure_canonical_format`.
- `preprocessing/_normalize.py` _ `normalize_pearson_residuals` uses `_check_gpu_X(X)` + `_ensure_canonical_format(X)`.
- `preprocessing/_hvg/_pearson_residuals.py` _ same for the `pearson_residuals` HVG flavor.
- `tests/test_normalization.py` _ adds `test_normalize_pearson_residuals_preserves_input_matrix`, which feeds a non-canonical sparse `adata.X` and asserts the matrix is unchanged after the call.
- `docs/release-notes/0.15.1.md` _ bug-fix entry.