### PR TITLE
fix inplaces for log1p and scale

### DIFF
--- a/docs/release-notes/0.16.0.md
+++ b/docs/release-notes/0.16.0.md
@@ -15,6 +15,7 @@
 ```
 * {func}`~rapids_singlecell.pp.neighbors` with ``method="jaccard"`` no longer crashes with ``CUDA_ERROR_ILLEGAL_ADDRESS`` on large datasets where ``n_obs * (n_neighbors - 1)**2`` exceeds ``2**31`` {pr}`700` {smaller}`S Dicks`
 * {func}`~rapids_singlecell.pp.pca` no longer imports a removed cuML internal, fixing ``ImportError`` on recent cuML builds {pr}`708` {smaller}`S Dicks`
+* Fix {func}`~rapids_singlecell.pp.scale` with ``obsm`` and metadata changes from {func}`~rapids_singlecell.pp.log1p` with ``inplace=False`` {pr}`719` {smaller}`S Dicks`
 
 ```{rubric} Misc
 ```

--- a/src/rapids_singlecell/preprocessing/_normalize.py
+++ b/src/rapids_singlecell/preprocessing/_normalize.py
@@ -420,9 +420,9 @@ def log1p(
         X = X.copy()
 
     X = _calc_log1p(X, base=base)
-    adata.uns["log1p"] = {"base": base}
     if inplace:
         _set_obs_rep(adata, X, layer=layer, obsm=obsm)
+        adata.uns["log1p"] = {"base": base}
 
     if copy:
         return adata

--- a/src/rapids_singlecell/preprocessing/_scale.py
+++ b/src/rapids_singlecell/preprocessing/_scale.py
@@ -126,8 +126,9 @@ def scale(
 
     if inplace:
         _set_obs_rep(adata, X, layer=layer, obsm=obsm)
-        adata.var[str_mean_std[0]] = means.get()
-        adata.var[str_mean_std[1]] = std.get()
+        if obsm is None:
+            adata.var[str_mean_std[0]] = means.get()
+            adata.var[str_mean_std[1]] = std.get()
 
     if copy:
         return adata

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -158,6 +158,17 @@ def test_log1p_base(use_array, dtype, sparse, base):
         assert cudata.uns["log1p"]["base"] == base
 
 
+def test_log1p_inplace_false_does_not_write_metadata():
+    X = cp.array([[1.0, 2.0], [3.0, 4.0]], dtype=cp.float32)
+    adata = AnnData(X.copy())
+
+    result = rsc.pp.log1p(adata, inplace=False)
+
+    cp.testing.assert_array_equal(adata.X, X)
+    cp.testing.assert_allclose(result, cp.log1p(X))
+    assert "log1p" not in adata.uns
+
+
 @pytest.mark.parametrize("use_array", [False, True])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("sparse", [True, False])

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -113,6 +113,20 @@ def test_scale_simple(dtype):
     )
 
 
+def test_scale_obsm_does_not_write_var_statistics():
+    adata = AnnData(cp.ones((3, 4), dtype=cp.float32))
+    adata.obsm["X_embedding"] = cp.array([[1, 2], [2, 4], [3, 6]], dtype=cp.float32)
+
+    rsc.pp.scale(adata, obsm="X_embedding")
+
+    cp.testing.assert_allclose(
+        adata.obsm["X_embedding"],
+        cp.array([[-1, -1], [0, 0], [1, 1]], dtype=cp.float32),
+    )
+    assert "mean" not in adata.var
+    assert "std" not in adata.var
+
+
 @pytest.mark.parametrize(
     "typ", [np.array, csr_matrix, csc_matrix], ids=lambda x: x.__name__
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `log1p` now preserves input data correctly when run without in-place updates, and no longer writes unnecessary metadata.
  * Scaling embeddings no longer adds summary statistics to feature metadata when the operation targets embedding data.
  * `scale` now updates feature statistics only when scaling the main matrix or a layer, improving consistency across data locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->