### PR TITLE
move to hatchling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -183,7 +183,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CUDA_ARCHS=${{ matrix.CUDA_SUFFIX.label == 'cuda12' && '75-real;80-real;86-real;89-real;90' || '75-real;80-real;86-real;89-real;90-real;100-real;120' }}
-            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RAPIDS_SINGLECELL=${{ steps.source-version.outputs.version }}
+            RSC_VERSION=${{ steps.source-version.outputs.version }}
           #cache-from: type=registry,ref=ghcr.io/${{ github.repository }}
           build-contexts: |
             rapids-singlecell-deps=docker-image://${{ fromJSON(steps.meta-base.outputs.json).tags[0] }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,21 +50,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get version from setuptools-scm
+      - name: Get version from hatch-vcs
         id: version
         run: |
-          pip install setuptools-scm
-          VERSION=$(python -m setuptools_scm)
+          pip install hatchling hatch-vcs
+          VERSION=$(python -m hatchling version)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"
 
       - name: Set package name, extras, and CUDA archs for CUDA ${{ matrix.cuda_major }}
         run: |
-          python3 - ${{ matrix.cuda_major }} "${{ matrix.cuda_archs }}" <<'SCRIPT'
+          python3 - ${{ matrix.cuda_major }} "${{ matrix.cuda_archs }}" "${{ steps.version.outputs.version }}" <<'SCRIPT'
           import sys, pathlib
 
           cuda = sys.argv[1]
           cuda_archs = sys.argv[2]
+          version = sys.argv[3]
           other = "13" if cuda == "12" else "12"
           path = pathlib.Path("pyproject.toml")
           text = path.read_text()
@@ -89,6 +90,10 @@ jobs:
           text = text.replace(
               'name = "rapids-singlecell"',
               f'name = "rapids-singlecell-cu{cuda}"',
+          )
+          text = text.replace(
+              'dynamic = [ "version" ]',
+              f'version = "{version}"',
           )
           # Rename matching extra to "rapids", remove the other
           text = text.replace(f'rapids-cu{cuda} = [', 'rapids = [')
@@ -140,12 +145,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.version.outputs.version }}
           CIBW_BUILD: 'cp312-*'
           CIBW_SKIP: '*-musllinux*'
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.os == 'linux-intel' && matrix.cibw_image || '' }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.os == 'linux-arm' && matrix.cibw_image || '' }}
-          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION
           CIBW_ENVIRONMENT: >
             CUDA_PATH=/usr/local/cuda
             LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,8 +112,8 @@ jobs:
           rmm_build_req = f'    "librmm-cu{cuda}>=25.12,<25.13",\n'
           if f'"librmm-cu{cuda}>=25.12"' not in build_system_text:
               build_system_text = build_system_text.replace(
-                  ']\nbuild-backend = "scikit_build_core.build"',
-                  f'{rmm_build_req}]\nbuild-backend = "scikit_build_core.build"',
+                  ']\nbuild-backend =',
+                  f'{rmm_build_req}]\nbuild-backend =',
                   1,
               )
           text = build_system_text + "[project]" + project_text

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,17 +9,20 @@ ENV PATH=/opt/conda/bin:$PATH
 # pick up the CUDA-matched librmm instead of a mismatched PyPI wheel.
 ENV CMAKE_PREFIX_PATH=/opt/conda
 ARG CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120"
-ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RAPIDS_SINGLECELL=0.0.0
+ARG RSC_VERSION=0.0.0
 
 COPY --from=source . /src/rapids_singlecell
 
 RUN <<EOF
 # install rapids_singlecell from source (compiled for all supported GPU architectures)
 set -x
-export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RAPIDS_SINGLECELL
 cd /src/rapids_singlecell
+# The Docker source context has no .git metadata, so use the version determined
+# by the workflow instead of asking hatch-vcs to derive it inside the image.
+sed -i 's/dynamic = \[ "version" \]/version = "'"${RSC_VERSION}"'"/' pyproject.toml
 # Set CUDA architectures directly in pyproject.toml (avoids SKBUILD_CMAKE_ARGS semicolon splitting)
 sed -i 's/CMAKE_CUDA_ARCHITECTURES = "native"/CMAKE_CUDA_ARCHITECTURES = "'"${CUDA_ARCHS}"'"/' pyproject.toml
+grep '^version = ' pyproject.toml
 grep CMAKE_CUDA_ARCHITECTURES pyproject.toml
 # Build with --no-build-isolation so the compile uses the conda env's
 # CUDA-matched librmm/rapids_logger headers. With isolation, PEP 517 would pull

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,6 @@ grep CMAKE_CUDA_ARCHITECTURES pyproject.toml
 # errors on both cu12 (toolkit older than the latest librmm) and cu13 (wrong
 # cu12 variant). Install the PEP 517 backend deps first since isolation is off;
 # the conda env already provides the librmm/rapids_logger headers + cmake config.
-/opt/conda/bin/python -m pip install --no-cache-dir scikit-build-core nanobind setuptools-scm cmake ninja
+/opt/conda/bin/python -m pip install --no-cache-dir hatchling 'scikit-build-core[hatchling]' hatch-vcs nanobind cmake ninja
 /opt/conda/bin/python -m pip install --no-cache-dir --no-build-isolation -e .
 EOF

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -259,7 +259,7 @@ Each wheel contains:
 - `.pyi` type stubs for IDE support
 - `py.typed` PEP 561 marker
 
-Source files (`.cu`, `.cuh`, `.h`) are excluded from wheels via `wheel.exclude` in `pyproject.toml`.
+Source files (`.cu`, `.cuh`, `.h`) are excluded from wheels via Hatchling's wheel target configuration in `pyproject.toml`.
 They are included in the source distribution for self-compilation.
 
 ### CUDA architectures

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,14 +137,14 @@ pip install "rapids-singlecell @ git+https://github.com/scverse/rapids-singlecel
 ```
 
 This compiles the CUDA kernels during installation. By default, kernels are compiled for your local GPU architecture only (`native`).
-To compile for different or multiple architectures, pass a config setting to override the CUDA architectures:
+To compile for different or multiple architectures, set the scikit-build-core environment variable that overrides the CUDA architectures:
 
 ```bash
 # Compile for a specific architecture (e.g., Ampere)
-pip install -C cmake.define.CMAKE_CUDA_ARCHITECTURES="80-real" "rapids-singlecell @ git+https://github.com/scverse/rapids-singlecell.git"
+SKBUILD_CMAKE_DEFINE_CMAKE_CUDA_ARCHITECTURES="80-real" pip install "rapids-singlecell @ git+https://github.com/scverse/rapids-singlecell.git"
 
 # Compile for multiple architectures
-pip install -C cmake.define.CMAKE_CUDA_ARCHITECTURES="80-real;86-real;89-real;90-real" "rapids-singlecell @ git+https://github.com/scverse/rapids-singlecell.git"
+SKBUILD_CMAKE_DEFINE_CMAKE_CUDA_ARCHITECTURES="80-real;86-real;89-real;90-real" pip install "rapids-singlecell @ git+https://github.com/scverse/rapids-singlecell.git"
 ```
 
 Common architecture codes:

--- a/docs/release-notes/0.16.0.md
+++ b/docs/release-notes/0.16.0.md
@@ -28,4 +28,4 @@
 * Scanpy compat: {func}`~rapids_singlecell.pp.pca` accepts ``return_info`` to return ``(X_pca, components, variance_ratio, variance)`` for matrix input {pr}`699` {smaller}`S Dicks`
 * Scanpy compat: {func}`~rapids_singlecell.pp.filter_genes` and {func}`~rapids_singlecell.pp.filter_cells` now write only the count column matching the threshold used (``n_counts``, ``n_cells`` or ``n_genes``) instead of always writing both, matching Scanpy {pr}`699` {smaller}`S Dicks`
 * Require ``scikit-build-core>=1.0.1`` to build; 1.0.0 truncated the shared ``testing`` namespace package in editable installs, breaking the test suite at collection {pr}`721` {smaller}`S Dicks`
-* Use Hatchling as the build backend, with scikit-build-core's Hatchling plugin building the nanobind CUDA extensions {smaller}`S Dicks`
+* Use Hatchling as the build backend, with scikit-build-core's Hatchling plugin building the nanobind CUDA extensions {pr}`724` {smaller}`S Dicks`

--- a/docs/release-notes/0.16.0.md
+++ b/docs/release-notes/0.16.0.md
@@ -28,3 +28,4 @@
 * Scanpy compat: {func}`~rapids_singlecell.pp.pca` accepts ``return_info`` to return ``(X_pca, components, variance_ratio, variance)`` for matrix input {pr}`699` {smaller}`S Dicks`
 * Scanpy compat: {func}`~rapids_singlecell.pp.filter_genes` and {func}`~rapids_singlecell.pp.filter_cells` now write only the count column matching the threshold used (``n_counts``, ``n_cells`` or ``n_genes``) instead of always writing both, matching Scanpy {pr}`699` {smaller}`S Dicks`
 * Require ``scikit-build-core>=1.0.1`` to build; 1.0.0 truncated the shared ``testing`` namespace package in editable installs, breaking the test suite at collection {pr}`721` {smaller}`S Dicks`
+* Use Hatchling as the build backend, with scikit-build-core's Hatchling plugin building the nanobind CUDA extensions {smaller}`S Dicks`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
 requires = [
-    "scikit-build-core>=1.0.1",
+    "hatchling",
+    "scikit-build-core[hatchling]>=1.0.1",
+    "hatch-vcs",
     "nanobind>=2.0.0",
-    "setuptools-scm>=8",
     # Wilcoxon links librmm at build time; generic isolated builds use CUDA 12.
     # 25.12+ provides the resource-ref API and flat RMM header path we use.
     "librmm-cu12>=25.12",
 ]
-build-backend = "scikit_build_core.build"
+build-backend = "hatchling.build"
 
 [project]
 name = "rapids-singlecell"
@@ -143,27 +144,32 @@ markers = [
     "array_api: array-API tests (currently unused, but needs to be specified here as we import anndata.tests.helpers, which uses it)",
 ]
 
-[tool.setuptools_scm]
-write_to = "src/rapids_singlecell/_version.py"
-# Optional but useful:
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
 version_scheme = "guess-next-dev"
 local_scheme = "node-and-date"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/rapids_singlecell/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = [ "src/rapids_singlecell", "src/testing" ]
+exclude = [ "**/*.cu", "**/*.cuh", "**/*.h" ]
+
+[tool.hatch.build.targets.wheel.hooks.scikit-build]
 
 [tool.scikit-build]
 # Use limited ABI wheels (one wheel for all Python minor versions on one platform)
 wheel.py-api = "cp312"
-wheel.packages = [ "src/rapids_singlecell", "src/testing" ]
-wheel.exclude = [ "**/*.cu", "**/*.cuh", "**/*.h" ]
 cmake.version = ">=3.24"
 cmake.build-type = "Release"
 ninja.version = ">=1.10"
-experimental = false
 # Default: use native arch for source builds (auto-detect user's GPU)
 # CI overrides via SKBUILD_CMAKE_DEFINE_CMAKE_CUDA_ARCHITECTURES env var
 cmake.define.CMAKE_CUDA_ARCHITECTURES = "native"
 build-dir = "build"
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = [ "src/rapids_singlecell/_version.py" ]
 
 # Use abi3audit to catch issues with Limited API wheels
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 rapids-cu13 = [
-    "cupy-cuda13x",
+    "cupy-cuda13x[ctk]",
     "cudf-cu13>=25.12",
     "cuml-cu13>=25.12",
     "cugraph-cu13>=25.12",
@@ -45,7 +45,7 @@ rapids-cu13 = [
     "librmm-cu13>=25.12",
 ]
 rapids-cu12 = [
-    "cupy-cuda12x",
+    "cupy-cuda12x[ctk]",
     "cudf-cu12>=25.12",
     "cuml-cu12>=25.12",
     "cugraph-cu12>=25.12",


### PR DESCRIPTION
This pre moves back to the now supported hatchling for scikit-build-core